### PR TITLE
UserRepositoryのstoreメソッドのテストのアサート方法を変更する

### DIFF
--- a/packages/backend/__tests__/infrastructure/repository/UserRepository.test.ts
+++ b/packages/backend/__tests__/infrastructure/repository/UserRepository.test.ts
@@ -11,13 +11,15 @@ import { UserRepository } from "../../../src/domain/repositories/UserRepository"
 import * as schema from "../../../src/infrastructure/database/schema";
 import { CreatedAt } from "../../../src/utils/CreatedAt";
 import { TestDbClient } from "../../setup/TestDbClient";
+import { assertEqualUserTable } from "../../table_assert/AssertEqualUserTable";
 import {
   createUserTableFixture,
   createUserTableFixtureWithoutFacultyAndDepartment
 } from "../../table_fixture/UserTableFixture";
 import {
   deleteFromDatabase,
-  insertToDatabase
+  insertToDatabase,
+  selectOneFromDatabase
 } from "../../utils/GenericTableHelper";
 
 describe("UserRepository Tests", () => {
@@ -119,8 +121,10 @@ describe("UserRepository Tests", () => {
       await userRepository.save(user);
 
       // assert
-      const actual = await userRepository.findBy(user.discordID);
-      expect(actual).toEqual(user);
+      const actualRecord = (await selectOneFromDatabase(
+        schema.user
+      )) as typeof schema.user.$inferSelect;
+      await assertEqualUserTable(user, actualRecord);
     });
 
     it("学部・学科がnullのユーザーを保存できること", async () => {
@@ -141,8 +145,10 @@ describe("UserRepository Tests", () => {
       await userRepository.save(user);
 
       // assert
-      const actual = await userRepository.findBy(user.discordID);
-      expect(actual).toEqual(user);
+      const actualRecord = (await selectOneFromDatabase(
+        schema.user
+      )) as typeof schema.user.$inferSelect;
+      await assertEqualUserTable(user, actualRecord);
     });
   });
 });

--- a/packages/backend/__tests__/table_assert/AssertEqualUserTable.ts
+++ b/packages/backend/__tests__/table_assert/AssertEqualUserTable.ts
@@ -1,0 +1,26 @@
+import { expect } from "vitest";
+import type { User } from "../../src/domain/models/User";
+import type * as schema from "../../src/infrastructure/database/schema";
+
+/**
+ * データベースのuserテーブルと引数で渡されたUserドメインオブジェクトが等しいことをアサート
+ * @param expectedUser 期待されるUserドメインオブジェクト
+ * @param actualRecord selectOneFromDatabaseから返される単一レコード
+ */
+export const assertEqualUserTable = async (
+  expectedUser: User,
+  actualRecord: typeof schema.user.$inferSelect
+): Promise<void> => {
+  const expectedRecord = {
+    id: expectedUser.userID.value.value,
+    discordId: expectedUser.discordID.getValue(),
+    discordUserName: expectedUser.discordUserName,
+    discordDiscriminator: expectedUser.discordDiscriminator,
+    discordAvatar: expectedUser.discordAvatar,
+    faculty: expectedUser.faculty?.getValue() ?? null,
+    department: expectedUser.department?.getValue() ?? null,
+    createdAt: expectedUser.createdAt.value
+  };
+
+  expect(actualRecord).toEqual(expectedRecord);
+};

--- a/packages/backend/__tests__/utils/GenericTableHelper.ts
+++ b/packages/backend/__tests__/utils/GenericTableHelper.ts
@@ -24,3 +24,30 @@ export const deleteFromDatabase = async (table: PgTable): Promise<void> => {
   const db = dbClient.getDb();
   await db.delete(table);
 };
+
+/**
+ * 汎用的なテーブル検索ヘルパー
+ * @param table 検索対象のテーブル
+ * @returns 検索結果の配列
+ */
+export const selectFromDatabase = async <T extends PgTable>(
+  table: T
+): Promise<(typeof table.$inferSelect)[]> => {
+  const dbClient = new TestDbClient();
+  const db = dbClient.getDb();
+  return await db.select().from(table);
+};
+
+/**
+ * 汎用的なテーブル検索ヘルパー（単一レコード）
+ * @param table 検索対象のテーブル
+ * @returns 検索結果の単一レコード
+ */
+export const selectOneFromDatabase = async <T extends PgTable>(
+  table: T
+): Promise<typeof table.$inferSelect> => {
+  const dbClient = new TestDbClient();
+  const db = dbClient.getDb();
+  const results = await db.select().from(table).limit(1);
+  return results[0];
+};


### PR DESCRIPTION
# 変更領域
- [x] backend
- [ ] frontend

# やったこと
現状の書き方だと、`findBy`が正常に動いていないとテストが落ちる仕組みになっているため、もっと汎用的な取得と、そのアサートが必要である。

そのため、直接DBから取得したレコードと、こちら側で期待しているレコードのアサートをするようにしたい

# 動作確認動画(スクリーンショット)
なし

# 確認したこと(デグレチェック)
- テストが通ること

# リリース時本番環境で確認すること
- テストなので不要
