### PR TITLE
new Date()して時刻を生成する値オブジェクトのアサートに対して、mockオブジェクトを返すようにする

### DIFF
--- a/packages/backend/__tests__/domain/User.test.ts
+++ b/packages/backend/__tests__/domain/User.test.ts
@@ -9,23 +9,15 @@ import {
 import { CreatedAt } from "../../src/utils/CreatedAt";
 
 const MOCK_UUID = "00000000-0000-0000-0000-000000";
-const MOCK_CREATED_AT = "2025-01-01T00:00:00.000Z";
+const MOCK_NOW = new Date("2025-01-01T00:00:00.000Z").getTime();
+
+vi.spyOn(Date, "now").mockReturnValue(MOCK_NOW);
 
 vi.mock("../../src/utils/UUID", () => {
   return {
     UUID: {
       new: vi.fn(() => ({
         value: MOCK_UUID
-      }))
-    }
-  };
-});
-
-vi.mock("../../src/utils/CreatedAt", () => {
-  return {
-    CreatedAt: {
-      new: vi.fn(() => ({
-        value: MOCK_CREATED_AT
       }))
     }
   };

--- a/packages/backend/__tests__/domain/UserAuth.test.ts
+++ b/packages/backend/__tests__/domain/UserAuth.test.ts
@@ -9,34 +9,15 @@ import {
 import { CreatedAt } from "../../src/utils/CreatedAt";
 
 const MOCK_UUID = "00000000-0000-0000-0000-000000";
-const MOCK_CREATED_AT = "2025-01-01T00:00:00.000Z";
-const MOCK_EXPIRES_AT = "2025-01-01T00:00:00.000Z";
+const MOCK_NOW = new Date("2025-01-01T00:00:00.000Z").getTime();
+
+vi.spyOn(Date, "now").mockReturnValue(MOCK_NOW);
 
 vi.mock("../../src/domain/models/User", () => {
   return {
     UserID: {
       new: vi.fn(() => ({
         value: MOCK_UUID
-      }))
-    }
-  };
-});
-
-vi.mock("../../src/utils/CreatedAt", () => {
-  return {
-    CreatedAt: {
-      new: vi.fn(() => ({
-        value: MOCK_CREATED_AT
-      }))
-    }
-  };
-});
-
-vi.mock("../../src/utils/ExpiredAt", () => {
-  return {
-    ExpiredAt: {
-      new: vi.fn(() => ({
-        value: MOCK_EXPIRES_AT
       }))
     }
   };


### PR DESCRIPTION
## 変更領域
バックエンド

## 背景
テストで実行したメソッドと期待したメソッドの生成時のズレが発生し、テストが意図せず落ちてしまう


## やったこと
mockで時刻を生成し、new Date()している値オブジェクトのアサート全てをmockに置き換える

## 動作確認動画(スクリーンショット)
なし

## 確認したこと(デグレチェック)
テストが通ること

## リリース時本番環境で確認すること
テストなので影響なし
