### PR TITLE
[rename]ExpiredAt → ExpiresAtへのリネーム

### DIFF
--- a/packages/backend/__tests__/domain/UserAuth.test.ts
+++ b/packages/backend/__tests__/domain/UserAuth.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { UserID } from "../../src/domain/User";
 import {
   AccessToken,
-  ExpiredAt,
+  ExpiresAt,
   RefreshToken,
   UserAuth
 } from "../../src/domain/UserAuth";
@@ -38,7 +38,7 @@ describe("UserAuthDomainTest", () => {
         userId,
         AccessToken.from(accessTokenValue),
         RefreshToken.from(refreshTokenValue),
-        ExpiredAt.new(expiresIn),
+        ExpiresAt.new(expiresIn),
         scope,
         tokenType,
         CreatedAt.new()

--- a/packages/backend/__tests__/infrastructure/repository/UserAuthRepository.test.ts
+++ b/packages/backend/__tests__/infrastructure/repository/UserAuthRepository.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { UserID } from "../../../src/domain/User";
 import {
   AccessToken,
-  ExpiredAt,
+  ExpiresAt,
   RefreshToken,
   UserAuth
 } from "../../../src/domain/UserAuth";
@@ -64,7 +64,7 @@ describe("UserAuthRepository Tests", () => {
         UserID.from(userAuth1.userId),
         AccessToken.from(userAuth1.accessToken),
         RefreshToken.from(userAuth1.refreshToken),
-        ExpiredAt.from(userAuth1.expiresIn),
+        ExpiresAt.from(userAuth1.expiresIn),
         userAuth1.scope,
         userAuth1.tokenType,
         CreatedAt.from(userAuth1.createdAt)
@@ -84,7 +84,7 @@ describe("UserAuthRepository Tests", () => {
         UserID.from(userAuth2.userId),
         AccessToken.from(userAuth2.accessToken),
         RefreshToken.from(userAuth2.refreshToken),
-        ExpiredAt.from(userAuth2.expiresIn),
+        ExpiresAt.from(userAuth2.expiresIn),
         userAuth2.scope,
         userAuth2.tokenType,
         CreatedAt.from(userAuth2.createdAt)
@@ -126,7 +126,7 @@ describe("UserAuthRepository Tests", () => {
         UserID.from(userAuthRecord.userId),
         AccessToken.from(userAuthRecord.accessToken),
         RefreshToken.from(userAuthRecord.refreshToken),
-        ExpiredAt.from(userAuthRecord.expiresIn),
+        ExpiresAt.from(userAuthRecord.expiresIn),
         userAuthRecord.scope,
         userAuthRecord.tokenType,
         CreatedAt.from(userAuthRecord.createdAt)

--- a/packages/backend/src/domain/UserAuth.ts
+++ b/packages/backend/src/domain/UserAuth.ts
@@ -6,7 +6,7 @@ export class UserAuth {
     readonly userId: UserID,
     readonly accessToken: AccessToken,
     readonly refreshToken: RefreshToken,
-    readonly expiresIn: ExpiredAt,
+    readonly expiresIn: ExpiresAt,
     readonly scope: string,
     readonly tokenType: string,
     readonly createdAt: CreatedAt
@@ -24,7 +24,7 @@ export class UserAuth {
       userId,
       AccessToken.from(accessToken),
       RefreshToken.from(refreshToken),
-      ExpiredAt.new(expiresIn),
+      ExpiresAt.new(expiresIn),
       scope,
       tokenType,
       CreatedAt.new()
@@ -35,7 +35,7 @@ export class UserAuth {
     userId: UserID,
     accessToken: AccessToken,
     refreshToken: RefreshToken,
-    expiresIn: ExpiredAt,
+    expiresIn: ExpiresAt,
     scope: string,
     tokenType: string,
     createdAt: CreatedAt
@@ -68,15 +68,15 @@ export class RefreshToken {
   }
 }
 
-export class ExpiredAt {
+export class ExpiresAt {
   private constructor(public readonly value: Date) {}
 
-  static new(expiresIn: number): ExpiredAt {
-    return new ExpiredAt(new Date(Date.now() + expiresIn * 1000));
+  static new(expiresIn: number): ExpiresAt {
+    return new ExpiresAt(new Date(Date.now() + expiresIn * 1000));
   }
 
-  static from(expiredAt: Date): ExpiredAt {
-    return new ExpiredAt(expiredAt);
+  static from(expiresAt: Date): ExpiresAt {
+    return new ExpiresAt(expiresAt);
   }
 
   isExpired(): boolean {

--- a/packages/backend/src/infrastructure/repositories/UserAuthRepository.ts
+++ b/packages/backend/src/infrastructure/repositories/UserAuthRepository.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from "inversify";
 import { UserID } from "../../domain/User";
 import {
   AccessToken,
-  ExpiredAt,
+  ExpiresAt,
   RefreshToken,
   UserAuth
 } from "../../domain/UserAuth";
@@ -54,7 +54,7 @@ export class UserAuthRepository implements UserAuthRepositoryInterface {
       UserID.from(userAuthRecord.userId),
       AccessToken.from(userAuthRecord.accessToken),
       RefreshToken.from(userAuthRecord.refreshToken),
-      ExpiredAt.from(userAuthRecord.expiresIn),
+      ExpiresAt.from(userAuthRecord.expiresIn),
       userAuthRecord.scope,
       userAuthRecord.tokenType,
       CreatedAt.from(userAuthRecord.createdAt)


### PR DESCRIPTION
## 変更領域
バックエンド

## 背景
expiredAtよりexpiredAtの方がしっくりくる
会話: https://github.com/yusei53/monorepo-app/pull/97#discussion_r2300749098

## やったこと
expiredAt→expiresAtへのリネーム

## 確認したこと(デグレチェック)
なし

## リリース時本番環境で確認すること
なし