### PR TITLE
Fix failing UserAuth repository tests

### DIFF
--- a/packages/backend/__tests__/domain/UserAuth.test.ts
+++ b/packages/backend/__tests__/domain/UserAuth.test.ts
@@ -13,11 +13,13 @@ const MOCK_NOW = new Date("2025-01-01T00:00:00.000Z").getTime();
 
 vi.spyOn(Date, "now").mockReturnValue(MOCK_NOW);
 
-vi.mock("../../src/domain/models/User", () => {
+vi.mock("../../src/domain/User", () => {
   return {
     UserID: {
       new: vi.fn(() => ({
-        value: MOCK_UUID
+        value: {
+          value: MOCK_UUID
+        }
       }))
     }
   };


### PR DESCRIPTION
## 変更領域
バックエンド

## 背景
UserAuthリポジトリのテストが失敗していました。これは、テストファイル内のモックのインポートパスが誤っていたこと、およびUserIDのモック構造が実際のドメインモデルと一致していなかったことが原因でした。

## やったこと
- `packages/backend/__tests__/domain/UserAuth.test.ts` における `User` モジュールのインポートパスを修正しました。
- `UserID` のモック構造を、`value` プロパティが `UUID` オブジェクト（さらにその `value` プロパティにUUID文字列を持つ）を返すように修正しました。

## 動作確認動画(スクリーンショット)
なし

## 確認したこと(デグレチェック)
UserAuth関連のテストが全て正常にパスすることを確認しました。既存機能への影響はありません。

## リリース時本番環境で確認すること
なし

---
<a href="https://cursor.com/background-agent?bcId=bc-bc01e1fd-05dc-4e59-8e4c-13d0bd7f497b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bc01e1fd-05dc-4e59-8e4c-13d0bd7f497b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

