### PR TITLE
Remove state repository cleanup method and create PR

### DIFF
--- a/packages/backend/src/infrastructure/repositories/StateRepository.ts
+++ b/packages/backend/src/infrastructure/repositories/StateRepository.ts
@@ -1,4 +1,4 @@
-import { eq, lt } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { injectable } from "inversify";
 import { oauthState as oauthStateSchema } from "../../infrastructure/database/schema";
 import { db } from "../database/connection";
@@ -17,7 +17,6 @@ export interface StateRepositoryInterface {
     expiresAt: Date;
   } | null>;
   delete(sessionId: string): Promise<void>;
-  cleanup(): Promise<void>;
 }
 
 @injectable()
@@ -60,11 +59,5 @@ export class StateRepository implements StateRepositoryInterface {
     await db
       .delete(oauthStateSchema)
       .where(eq(oauthStateSchema.sessionId, sessionId));
-  }
-
-  async cleanup(): Promise<void> {
-    await db
-      .delete(oauthStateSchema)
-      .where(lt(oauthStateSchema.expiresAt, new Date()));
   }
 }


### PR DESCRIPTION
## 変更領域
バックエンド

## 背景
`StateRepository` に定義されていた `cleanup()` メソッドがコードベースのどこからも呼び出されておらず、未使用であったため削除しました。

## やったこと
- `StateRepositoryInterface` から `cleanup(): Promise<void>` メソッドを削除
- `StateRepository` クラスから `cleanup()` メソッドの実装を削除
- `cleanup` メソッドでのみ使用されていた `drizzle-orm` からの `lt` インポートを削除

## 動作確認動画(スクリーンショット)
なし

## 確認したこと(デグレチェック)
- 削除された `cleanup` メソッドは未使用であったため、既存機能への影響がないことを確認しました。
- `StateRepository` の他のメソッド（`create`, `get`, `delete`）が引き続き正常に動作することを確認しました。

## リリース時本番環境で確認すること
- OAuth認証フローなど、`StateRepository` を利用する主要な機能が正常に動作すること。

---
<a href="https://cursor.com/background-agent?bcId=bc-843e052d-6946-4d01-b78e-f7010122d5e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-843e052d-6946-4d01-b78e-f7010122d5e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

